### PR TITLE
Update doyoudo.js

### DIFF
--- a/doyoudo.js
+++ b/doyoudo.js
@@ -7,4 +7,4 @@ function doyoudo(){
 	wtiframe.setAttribute("fastforward","false");
 	wtiframe.setAttribute("switchwindow","false");
 }
-setTimeout(doyoudo,1000);
+window.onload = doyoudo();


### PR DESCRIPTION
经实测，原来的版本存在bug，现在setTimeout可能导致在页面加载完之前调用方法，建议采用经修改的版本。